### PR TITLE
fix(examples/encode): set dims in correct order

### DIFF
--- a/examples/encode.rs
+++ b/examples/encode.rs
@@ -22,7 +22,7 @@ fn main() {
 
     let mut par = Param::default_preset("medium", None).unwrap();
 
-    par = par.set_dimension(w, h);
+    par = par.set_dimension(h, w);
     par = par.param_parse("repeat_headers", "1").unwrap();
     par = par.param_parse("annexb", "1").unwrap();
     par = par.apply_profile("high").unwrap();


### PR DESCRIPTION
Per the API

```
pub fn set_dimension(self, height: usize, width: usize) -> Param
```

The order of the height and width parsed from the commandline were being used in the incorrect order.