### PR TITLE
x264-sys version bump 0.2.2

### DIFF
--- a/x264-sys/Cargo.toml
+++ b/x264-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x264-sys"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Luca Barbato <lu_zero@gentoo.org>"]
 license = "MIT"
 description = "FFI bindings to x264"


### PR DESCRIPTION
Bumps version to 0.2.2 so new release contains the updated dependencies.